### PR TITLE
Updated to work with latest version of papertrail.

### DIFF
--- a/lib/has_destroy_log.rb
+++ b/lib/has_destroy_log.rb
@@ -6,7 +6,7 @@ module HasDestroyLog
 
   class_methods do
     def has_destroy_log(**options)
-      if paper_trail_enabled_for_model?
+      if paper_trail.enabled?
         return
       end
 


### PR DESCRIPTION
We're going to be upgrading Papertrail to 5.2.3 to be Rails 5.1 compatible, and need to make this change in `has_destroy_log` in order to remove the following deprecation warning:

```
DEPRECATION WARNING: Use paper_trail.enabled? instead of paper_trail_enabled_for_model? (called from has_destroy_log at /usr/local/bundle/bundler/gems/has_destroy_log-03749f64d69a/lib/has_destroy_log.rb:9)
```