### PR TITLE
Upgrade for papertrail 9.0.0

### DIFF
--- a/lib/has_destroy_log.rb
+++ b/lib/has_destroy_log.rb
@@ -6,11 +6,9 @@ module HasDestroyLog
 
   class_methods do
     def has_destroy_log(**options)
-      if paper_trail.enabled?
-        return
-      end
+      return if PaperTrail.request.enabled_for_model?(self)
 
-      has_paper_trail :on => [:destroy], **options
+      has_paper_trail on: [:destroy], **options
     end
   end
 end


### PR DESCRIPTION
Fixes deprecation warning in papertrail 9.0.0:

```
DEPRECATION WARNING: MyModel.paper_trail.enabled? is deprecated, use PaperTrail.request.enabled_for_model?(MyModel). This new API makes it clear that this is a setting specific to the current request, not all threads. Also, all other request-variables now go through the same `request` method, so this new API is more consistent. (called from has_destroy_log at /usr/local/bundle/bundler/gems/has_destroy_log-3a326f43391a/lib/has_destroy_log.rb:9)
```